### PR TITLE
X out code points

### DIFF
--- a/draft-connolly-tls-mlkem-key-agreement.md
+++ b/draft-connolly-tls-mlkem-key-agreement.md
@@ -284,7 +284,7 @@ This document requests/registers two new entries to the TLS Supported
 Groups registry, according to the procedures in {{Section 6 of tlsiana}}.
 
  Value:
- : 0x0768 (please)
+ : 0xXXXX
 
  Description:
  : MLKEM768
@@ -303,7 +303,7 @@ Groups registry, according to the procedures in {{Section 6 of tlsiana}}.
 
 
  Value:
- : 0x1024 (please)
+ : 0xXXXX
 
  Description:
  : MLKEM1024


### PR DESCRIPTION
Even with the disclaimer that people shouldn't implement I-Ds there is still the chance that assigning a code point before the specification is done will cause some kind of interop headaches.  Can we remove these for now and then suggest 'em the second the *FINAL* FIPS is published.